### PR TITLE
Update CHON.hpp

### DIFF
--- a/src/CHON.hpp
+++ b/src/CHON.hpp
@@ -225,7 +225,7 @@ class CHON : public App {
   OSC
   */
   int port = 16447;             // osc port
-  char addr[10] = "127.0.0.1";  // ip address
+  char addr[15] = "127.0.0.1";  // ip address
   osc::Send client;             // create an osc client
   ParameterBool oscOn{"OSC On", "OSC", 0};
   ParameterBool oscX{"X disp", "OSC", 0};


### PR DESCRIPTION
Closes #2 

This customization enables CHON to send OSC messages to a different device on the network, if the IP address is longer than 10 characters. The change takes into account that the maximum length of an IPv4 address can be 15 characters.